### PR TITLE
Adding in inventory system with small sample scene + pre-made unit tests

### DIFF
--- a/Assets/Prefabs.meta
+++ b/Assets/Prefabs.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 912c57beb53250c4f8a00a612b390f13
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/SampleItem.prefab
+++ b/Assets/Prefabs/SampleItem.prefab
@@ -1,0 +1,47 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &413400418966893186
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 413400418966893196}
+  - component: {fileID: 413400418966893187}
+  m_Layer: 0
+  m_Name: SampleItem
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &413400418966893196
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 413400418966893186}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &413400418966893187
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 413400418966893186}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bb76d4fb1cab18e459c05df60036b4d7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  itemName: SampleItem
+  icon: {fileID: 10913, guid: 0000000000000000f000000000000000, type: 0}

--- a/Assets/Prefabs/SampleItem.prefab.meta
+++ b/Assets/Prefabs/SampleItem.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 2babc91bb714078459d879729d917ef6
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/InventoryScene.unity
+++ b/Assets/Scenes/InventoryScene.unity
@@ -1,0 +1,413 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 9
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_IndirectSpecularColor: {r: 0, g: 0, b: 0, a: 1}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 11
+  m_GIWorkflowMode: 1
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 1
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_FinalGather: 0
+    m_FinalGatherFiltering: 1
+    m_FinalGatherRayCount: 256
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 512
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 1
+    m_PVRDenoiserTypeDirect: 1
+    m_PVRDenoiserTypeIndirect: 1
+    m_PVRDenoiserTypeAO: 1
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 0}
+  m_UseShadowmask: 1
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 2
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    accuratePlacement: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &577128248
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 577128249}
+  - component: {fileID: 577128250}
+  m_Layer: 0
+  m_Name: InventoryHolder
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &577128249
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 577128248}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &577128250
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 577128248}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 737a25720182f1349b9e10a7887b442d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  itemsToStartWith:
+  - {fileID: 413400418966893187, guid: 2babc91bb714078459d879729d917ef6, type: 3}
+  _dumpContents: 0
+--- !u!1 &1396182644
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1396182646}
+  - component: {fileID: 1396182645}
+  m_Layer: 0
+  m_Name: Directional Light
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!108 &1396182645
+Light:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1396182644}
+  m_Enabled: 1
+  serializedVersion: 10
+  m_Type: 1
+  m_Shape: 0
+  m_Color: {r: 1, g: 0.95686275, b: 0.8392157, a: 1}
+  m_Intensity: 1
+  m_Range: 10
+  m_SpotAngle: 30
+  m_InnerSpotAngle: 21.80208
+  m_CookieSize: 10
+  m_Shadows:
+    m_Type: 2
+    m_Resolution: -1
+    m_CustomResolution: -1
+    m_Strength: 1
+    m_Bias: 0.05
+    m_NormalBias: 0.4
+    m_NearPlane: 0.2
+    m_CullingMatrixOverride:
+      e00: 1
+      e01: 0
+      e02: 0
+      e03: 0
+      e10: 0
+      e11: 1
+      e12: 0
+      e13: 0
+      e20: 0
+      e21: 0
+      e22: 1
+      e23: 0
+      e30: 0
+      e31: 0
+      e32: 0
+      e33: 1
+    m_UseCullingMatrixOverride: 0
+  m_Cookie: {fileID: 0}
+  m_DrawHalo: 0
+  m_Flare: {fileID: 0}
+  m_RenderMode: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingLayerMask: 1
+  m_Lightmapping: 4
+  m_LightShadowCasterMode: 0
+  m_AreaSize: {x: 1, y: 1}
+  m_BounceIntensity: 1
+  m_ColorTemperature: 6570
+  m_UseColorTemperature: 0
+  m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_UseBoundingSphereOverride: 0
+  m_ShadowRadius: 0
+  m_ShadowAngle: 0
+--- !u!4 &1396182646
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1396182644}
+  m_LocalRotation: {x: 0.40821788, y: -0.23456968, z: 0.10938163, w: 0.8754261}
+  m_LocalPosition: {x: 0, y: 3, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+--- !u!1 &2028882087
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2028882090}
+  - component: {fileID: 2028882089}
+  - component: {fileID: 2028882088}
+  m_Layer: 0
+  m_Name: Main Camera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!81 &2028882088
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2028882087}
+  m_Enabled: 1
+--- !u!20 &2028882089
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2028882087}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_FocalLength: 50
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!4 &2028882090
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2028882087}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 1, z: -10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &413400419132307172
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 413400418966893186, guid: 2babc91bb714078459d879729d917ef6,
+        type: 3}
+      propertyPath: m_Name
+      value: SampleItem
+      objectReference: {fileID: 0}
+    - target: {fileID: 413400418966893196, guid: 2babc91bb714078459d879729d917ef6,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 413400418966893196, guid: 2babc91bb714078459d879729d917ef6,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 413400418966893196, guid: 2babc91bb714078459d879729d917ef6,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 413400418966893196, guid: 2babc91bb714078459d879729d917ef6,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 413400418966893196, guid: 2babc91bb714078459d879729d917ef6,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 413400418966893196, guid: 2babc91bb714078459d879729d917ef6,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 413400418966893196, guid: 2babc91bb714078459d879729d917ef6,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 413400418966893196, guid: 2babc91bb714078459d879729d917ef6,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 413400418966893196, guid: 2babc91bb714078459d879729d917ef6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 413400418966893196, guid: 2babc91bb714078459d879729d917ef6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 413400418966893196, guid: 2babc91bb714078459d879729d917ef6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 2babc91bb714078459d879729d917ef6, type: 3}

--- a/Assets/Scenes/InventoryScene.unity.meta
+++ b/Assets/Scenes/InventoryScene.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 62aee094fe828954d96ef588a148ee0e
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts.meta
+++ b/Assets/Scripts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0c3cb4eb44e978a4cbfceac5aea8bfd7
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/BGJ-2020-Assembly.asmdef
+++ b/Assets/Scripts/BGJ-2020-Assembly.asmdef
@@ -1,0 +1,3 @@
+﻿{
+	"name": "BGJ-2020-Assembly"
+}

--- a/Assets/Scripts/BGJ-2020-Assembly.asmdef.meta
+++ b/Assets/Scripts/BGJ-2020-Assembly.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: ba31cc28e7cc2ea4e9f7eaf7f6c0899a
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Systems.meta
+++ b/Assets/Scripts/Systems.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 22e1f7a338c3de74e9d25b9ec663d2c1
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Systems/Inventory.meta
+++ b/Assets/Scripts/Systems/Inventory.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4826744ebcd3b20499642e49b2918535
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Systems/Inventory/Inventory.cs
+++ b/Assets/Scripts/Systems/Inventory/Inventory.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEngine;
+
+namespace com.runtime.GameJamBois.BGJ20201.Items {
+    /// <summary>
+    /// A singleton instance of a player's inventory. Uses storage logic from parent class.
+    /// 
+    /// It also provides a delegate to subscribe to, if you want something
+    /// specific to happen when the inventory is updated (very useful for UI updates).
+    /// </summary>
+    public class Inventory : ItemStorage {
+        // a singleton instance of this class to be used across all of the game
+        private static Inventory _instance;
+
+        /// Event that will trigger upon the inventory being changed
+        public event Action OnInventoryChange = delegate { };
+
+        // Useful for dumping what's in the inventory from within the inspector
+        // will be quickly toggled off right after logging
+        [Tooltip("Toggle this to quickly dump/log what's in the inventory.")]
+        [SerializeField]
+        private bool _dumpContents;
+
+        private void Awake() {
+            // the very first time this script is loaded, we want to save this instance
+            // as the singleton for this class
+            if (_instance == null) {
+                _instance = this;
+                DontDestroyOnLoad(gameObject);
+                // otherwise if it tries to instantiate itself again,
+                // we want to destroy that object!
+            } else {
+                Destroy(gameObject);
+            }
+        }
+
+        private void Update() {
+            if (_dumpContents) {
+                inventoryDump();
+                _dumpContents = false;
+            }
+
+            // this will call all methods that are listening for inventory updates
+            updateInventoryIfNeeded();
+        }
+
+        /// <summary>
+        /// Gives you the current instance of the inventory!
+        /// </summary>
+        public static Inventory GetInstance() {
+            return _instance;
+        }
+
+        /// <summary>
+        /// If the inventory has been updated through something,
+        /// then this method will call all methods attached to it's
+        /// OnInventoryChange delegate list.
+        /// TODO: consider moving this into the base storage, since that's where
+        /// the variable is (and other storage systems may want that too).
+        /// </summary>
+        private void updateInventoryIfNeeded() {
+            if (inventoryUpdated) {
+                inventoryUpdated = false;
+                OnInventoryChange();
+            }
+        }
+
+        /***** UTILITIES AND USEFUL METHODS ******/
+
+        /// <summary>
+        /// See what's currently in your inventory.
+        /// </summary>
+        public void inventoryDump() {
+            Debug.Log("**********Starting Inventory Dump**********");
+            string inventoryDump = "[";
+            foreach (string itemName in itemCountStorage.Keys) {
+                inventoryDump = inventoryDump + "{" + itemName + ": " + itemCountStorage[itemName] + "},";
+            }
+
+            inventoryDump = inventoryDump.Remove(inventoryDump.Length - 1, 1);
+            inventoryDump = inventoryDump + "]";
+            Debug.Log(inventoryDump);
+
+            Debug.Log("**********Inventory Dump Finished**********");
+        }
+    }
+}

--- a/Assets/Scripts/Systems/Inventory/Inventory.cs.meta
+++ b/Assets/Scripts/Systems/Inventory/Inventory.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 737a25720182f1349b9e10a7887b442d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Systems/Inventory/ItemStorage.cs
+++ b/Assets/Scripts/Systems/Inventory/ItemStorage.cs
@@ -206,5 +206,21 @@ namespace com.runtime.GameJamBois.BGJ20201.Items {
                 itemCountStorage.Remove(item.getItemName());
             }
         }
+
+        /***** METHODS FOR TESTS ONLY *****/
+        public ArrayList GetOrderedStorage() {
+            TestUtils.logTestingWarning();
+            return itemOrderStorage;
+        }
+
+        public Dictionary<string, int> GetItemCountStorage() {
+            TestUtils.logTestingWarning();
+            return itemCountStorage;
+        }
+
+        public void SetArrayForItemsToStartWith(Item[] items) {
+            TestUtils.logTestingWarning();
+            itemsToStartWith = items;
+        }
     }
 }

--- a/Assets/Scripts/Systems/Inventory/ItemStorage.cs
+++ b/Assets/Scripts/Systems/Inventory/ItemStorage.cs
@@ -1,0 +1,210 @@
+﻿using UnityEngine;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace com.runtime.GameJamBois.BGJ20201.Items {
+    /// <summary>
+    /// A basic storage system for items. Stores one item -> count.
+    /// Does not include stacking limits yet, and each type of item is stored
+    /// at 1 slot (so you can't have 64 of one item in one index and 64 in another,
+    /// you'd have 128 in 1 slot).
+    /// </summary>
+    public class ItemStorage : MonoBehaviour{
+        // simple item name to count storage
+        protected Dictionary<string, int> itemCountStorage = new Dictionary<string, int>();
+
+        // tracks order of items in the storage, and keeps 1 of each 'Item'
+        protected ArrayList itemOrderStorage = new ArrayList();
+
+        // items to initialize the storage with
+        [Tooltip("Want to start with items when the game starts? Add them here!")]
+        [SerializeField]
+        protected Item[] itemsToStartWith;
+
+        // internal bool to know if the inventory has been updated
+        protected static bool inventoryUpdated = false;
+
+        // NOTE: if you're not careful you might overload this Start()
+        // make sure to use base.Start() if you need to update your start
+        protected void Start() {
+            // if we have any items to start with, go ahead and add that here.
+            ProcessStartingItems();
+        }
+
+        /******* READING/INSPECTING STORAGE *******/
+
+        /// <summary>
+        /// Reads this item in the storage
+        /// </summary>
+        public Item GetItemAt(int i) {
+            return (Item)itemOrderStorage[i];
+        }
+
+        /// <summary>
+        /// Literally returns you the next item in the desired direction.
+        /// 
+        /// This does not do any sort of logic checking other than that.
+        /// </summary>
+        public int GetNextItemIndex(int startIndex, bool leftOrRight) {
+            return SafeIncrement(startIndex, leftOrRight);
+        }
+
+        /// <summary>
+        /// Total number of unique item types in this storage.
+        /// </summary>
+        public int GetUniqueItemCount() {
+            return itemCountStorage.Keys.Count;
+        }
+
+        /// <summary>
+        /// Count of a certain item type.
+        /// </summary>
+        public int GetItemCount(Item item) {
+            return itemCountStorage[item.getItemName()];
+        }
+
+        /// <summary>
+        /// Safely increments the index throughout the inventory, and wraps
+        /// back around should you hit the limits.
+        /// </summary>
+        private int SafeIncrement(int startIndex, bool leftToRight) {
+            int index = startIndex;
+            int change = 1;
+            if (!leftToRight) {
+                change = -1;
+            }
+
+            index += change;
+            if (leftToRight) {
+                if (index == itemOrderStorage.Count) {
+                    index = 0;
+                }
+            } else {
+                if (index == -1) {
+                    index = itemOrderStorage.Count - 1;
+                }
+            }
+
+            return index;
+        }
+
+        /******* ADDING TO STORAGE *******/
+
+        /// <summary>
+        /// Simple add method. Creates entry if none,
+        /// otherwise increments the item that already exists.
+        /// </summary>
+        public void Add(Item item, int count) {
+            // prevents trying to add 0 the first time!
+            if (count == 0) {
+                return;
+            }
+
+            // if no entry exists, add an entry now
+            if (!DoesItemExist(item)) {
+                itemCountStorage.Add(item.getItemName(), count);
+                itemOrderStorage.Add(item);
+            } else {
+                itemCountStorage[item.getItemName()] += count;
+            }
+
+            inventoryUpdated = true;
+            Debug.Log("Inventory: added [" + count + "] item(s) [" + item + "]");
+        }
+
+        /// <summary>
+        /// If you just want to add 1 item, this method is what you want.
+        /// </summary>
+        public void Add(Item item) {
+            Add(item, 1);
+        }
+
+        /******* REMOVING FROM STORAGE *******/
+
+        /// <summary>
+        /// Removes this item from the object storage if found.
+        /// 
+        /// If there's no more of that item, completely removes the item from the storage.
+        /// </summary>
+        public void Remove(Item item, int count) {
+            try {
+                itemCountStorage[item.getItemName()] -= count;
+
+                // remove from the orderInventory if this is the last one!
+                // also remove the key from the dictionary too
+                if (itemCountStorage[item.getItemName()] == 0) {
+                    RemoveItemCompletely(item);
+                }
+            } catch (KeyNotFoundException e) {
+                Debug.Log("Inventory: no item exists for: " + item);
+                return;
+            }
+
+            Debug.Log("Inventory: removed [" + count + "] item(s) [" + item + "]");
+            inventoryUpdated = true;
+        }
+
+        /// <summary>
+        /// Remove just 1 of this item.
+        /// </summary>
+        public void Remove(Item item) {
+            Remove(item, 1);
+        }
+
+        /// <summary>
+        /// Simple as can be, reads in items you want to start this
+        /// inventory off with.
+        /// 
+        /// If no items were added we'll just skip this.
+        /// </summary>
+        public void ProcessStartingItems() {
+            if (itemsToStartWith == null) {
+                return;
+            }
+
+            foreach (Item item in itemsToStartWith) {
+                Add(item);
+            }
+        }
+
+        /// <summary>
+        /// Is there an entry in the itemInventory for this?
+        /// </summary>
+        public bool DoesItemExist(Item item) {
+            return itemCountStorage.ContainsKey(item.getItemName());
+        }
+
+        /// <summary>
+        /// Removes any objects that include '(Clone)' in the name,
+        /// in case you start adding in items this way.
+        /// </summary>
+        protected string stripOutClone(GameObject obj) {
+            string name = obj.name;
+            return name.Replace("(Clone)", "").Trim();
+        }
+
+        /// <summary>
+        /// Fully removes this item from both storage locations,
+        /// like wiping the entry.
+        /// 
+        /// Very destructive, hense it being private.
+        /// </summary>
+        private void RemoveItemCompletely(Item item) {
+            int indexToRemove = -1;
+            for (int i = 0; i < itemOrderStorage.Count; i++) {
+                Item itemInArrayList = (Item)itemOrderStorage[i];
+                if (itemInArrayList.Equals(item)) {
+                    indexToRemove = i;
+                    i = itemOrderStorage.Count;
+                }
+            }
+
+            if (indexToRemove == -1) {
+                Debug.Log("Trying to remove an item that does not exist in the ordered inventory array!");
+            } else {
+                itemOrderStorage.RemoveAt(indexToRemove);
+                itemCountStorage.Remove(item.getItemName());
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Systems/Inventory/ItemStorage.cs.meta
+++ b/Assets/Scripts/Systems/Inventory/ItemStorage.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 65054e8ab6a4fba4091e0a336d7e41be
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Systems/Items.meta
+++ b/Assets/Scripts/Systems/Items.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c08b8d0d2d0033d4db38b54a7624e591
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Systems/Items/Item.cs
+++ b/Assets/Scripts/Systems/Items/Item.cs
@@ -1,34 +1,36 @@
 ﻿using UnityEngine;
 using UnityEngine.UI;
 
-/// <summary>
-/// Stores things you'll need to know about an item in your inventory!
-/// </summary>
-public class Item : MonoBehaviour {
-    [SerializeField]
-    private string itemName;
-
-    [SerializeField]
-    private Sprite icon;
-
-    public void construct(string name) {
-        itemName = name;
-    }
-
-    public Sprite getIcon() {
-        return icon;
-    }
-
-    public string getItemName() {
-        return itemName;
-    }
-
+namespace com.runtime.GameJamBois.BGJ20201.Items {
     /// <summary>
-    /// Defines our own definition of 'Equals' for items.
-    /// Item equivalency is based on their names.
+    /// Stores things you'll need to know about an item in your inventory!
     /// </summary>
-    public override bool Equals(object other) {
-        Item otherItem = (Item) other;
-        return itemName.Equals(otherItem.getItemName());
+    public class Item : MonoBehaviour {
+        [SerializeField]
+        private string itemName;
+
+        [SerializeField]
+        private Sprite icon;
+
+        public void construct(string name) {
+            itemName = name;
+        }
+
+        public Sprite getIcon() {
+            return icon;
+        }
+
+        public string getItemName() {
+            return itemName;
+        }
+
+        /// <summary>
+        /// Defines our own definition of 'Equals' for items.
+        /// Item equivalency is based on their names.
+        /// </summary>
+        public override bool Equals(object other) {
+            Item otherItem = (Item)other;
+            return itemName.Equals(otherItem.getItemName());
+        }
     }
 }

--- a/Assets/Scripts/Systems/Items/Item.cs
+++ b/Assets/Scripts/Systems/Items/Item.cs
@@ -1,0 +1,34 @@
+﻿using UnityEngine;
+using UnityEngine.UI;
+
+/// <summary>
+/// Stores things you'll need to know about an item in your inventory!
+/// </summary>
+public class Item : MonoBehaviour {
+    [SerializeField]
+    private string itemName;
+
+    [SerializeField]
+    private Sprite icon;
+
+    public void construct(string name) {
+        itemName = name;
+    }
+
+    public Sprite getIcon() {
+        return icon;
+    }
+
+    public string getItemName() {
+        return itemName;
+    }
+
+    /// <summary>
+    /// Defines our own definition of 'Equals' for items.
+    /// Item equivalency is based on their names.
+    /// </summary>
+    public override bool Equals(object other) {
+        Item otherItem = (Item) other;
+        return itemName.Equals(otherItem.getItemName());
+    }
+}

--- a/Assets/Scripts/Systems/Items/Item.cs.meta
+++ b/Assets/Scripts/Systems/Items/Item.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bb76d4fb1cab18e459c05df60036b4d7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Utils.meta
+++ b/Assets/Scripts/Utils.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 92910528d49013d45b9743002f8168e2
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Utils/TestUtils.cs
+++ b/Assets/Scripts/Utils/TestUtils.cs
@@ -1,0 +1,13 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class TestUtils {
+    /// <summary>
+    /// Warning to users that the method you're using is intended for testing purposes
+    /// only, so do not use it directly. Behaviour is undefined if you do.
+    /// </summary>
+    public static void logTestingWarning() {
+        Debug.LogWarning("This method is not intended to be used inside of your actual game.");
+    }
+}

--- a/Assets/Scripts/Utils/TestUtils.cs.meta
+++ b/Assets/Scripts/Utils/TestUtils.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6120f5530355dff4f931da627eb95fd0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests.meta
+++ b/Assets/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2785c6f68419e644eb8f10b03a8b6577
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Inventory.meta
+++ b/Assets/Tests/Inventory.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ae272ee08b9a77644ab3d7f10f92f87c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Inventory/InventoryBaseTest.cs
+++ b/Assets/Tests/Inventory/InventoryBaseTest.cs
@@ -1,0 +1,40 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using com.runtime.GameJamBois.BGJ20201.Items;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Tests {
+    public class InventoryBasetest : UnityPlayBaseTest {
+        protected Inventory inventory;
+        protected GameObject gameObjectWithInventory;
+
+        /// <summary>
+        /// Wrapper to add a new item to the inventory.
+        /// </summary>
+        protected Item addNewItemToInventory(string name) {
+            Item item = getNewItem(name);
+            inventory.Add(item);
+            return item;
+        }
+
+        /// <summary>
+        /// Create a GO with the inventory component already attached.
+        /// </summary>
+        [SetUp]
+        public void addGOWithInventory() {
+            gameObjectWithInventory = addGOAndStoreInDestroyList(typeof(Inventory));
+            inventory = gameObjectWithInventory.GetComponent<Inventory>();
+        }
+
+        /// <summary>
+        /// Always make this inventory object null after every test!
+        /// </summary>
+        [TearDown]
+        public void wipeInventoryRef() {
+            inventory = null;
+            gameObjectWithInventory = null;
+        }
+    }
+}

--- a/Assets/Tests/Inventory/InventoryBaseTest.cs.meta
+++ b/Assets/Tests/Inventory/InventoryBaseTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b4d4b5b640186cc43892627a707ac3f1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Inventory/Inventory_AddingTests.cs
+++ b/Assets/Tests/Inventory/Inventory_AddingTests.cs
@@ -1,0 +1,110 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using com.runtime.GameJamBois.BGJ20201.Items;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Tests {
+    public class Inventory_AddingTests : InventoryBasetest {
+
+        [UnityTest]
+        public IEnumerator itemAddsToDictionaryTest(){
+            addNewItemToInventory(ITEM_ONE);
+
+            // now read the dictionary to make sure it's actually added in
+            var dict = inventory.GetItemCountStorage();
+            Assert.IsTrue(dict.ContainsKey(ITEM_ONE),
+                "Inventory does not add a new entry into the dictionary when a new item is added.");
+            yield return null;
+        }
+
+        [UnityTest]
+        public IEnumerator itemAddsToObjectArrayTest() {
+            bool containsAddedItem = false;
+            Item addedItem = addNewItemToInventory(ITEM_ONE);
+
+            // now look through this arraylist for the item you just added
+            ArrayList arrayList = inventory.GetOrderedStorage();
+            foreach(Item item in arrayList) {
+                if (item == addedItem) {
+                    containsAddedItem = true;
+                }
+            }
+
+            Assert.IsTrue(containsAddedItem, "Inventory does not add the new item to the orderedArrayList.");
+            yield return null;
+        }
+
+        [UnityTest]
+        public IEnumerator addedItem_DoesItemExistMethodTest() {
+            Item item = addNewItemToInventory(ITEM_ONE);
+
+            Assert.IsTrue(inventory.DoesItemExist(item),
+                "Inventory does not show that an added item is there.");
+            yield return null;
+        }
+
+        [UnityTest]
+        public IEnumerator noItemAdded_DoesItemExistMethodTest() {
+            // this item is actually added to the inventory
+            addNewItemToInventory(ITEM_ONE);
+
+            // this item is not, but it does exist in the scene
+            Item itemNotInInventory = getNewItem(ITEM_TWO);
+
+            Assert.IsFalse(inventory.DoesItemExist(itemNotInInventory),
+                "Inventory shows an item that was never added to the inventory, is actually there.");
+            yield return null;
+        }
+
+        [UnityTest]
+        public IEnumerator totalItemCountTest() {
+            int totalItemsToAdd = 10;
+            Item item = addNewItemToInventory(ITEM_ONE);
+            for (int i = 0; i < totalItemsToAdd-1; i++) {
+                addNewItemToInventory(ITEM_ONE);
+            }
+
+            Assert.AreEqual(totalItemsToAdd, inventory.GetItemCount(item),
+                "Total items in the inventory does not match how many were added.");
+            yield return null;
+        }
+
+        [UnityTest]
+        public IEnumerator addXTest() {
+            int totalItemsToAdd = Random.Range(0, 20);
+            Item itemToAdd = getNewItem(ITEM_ONE);
+            inventory.Add(itemToAdd, totalItemsToAdd);
+
+            Assert.AreEqual(totalItemsToAdd, inventory.GetItemCount(itemToAdd),
+                "Adding in a variable amount of items does not actually add that many items.");
+            yield return null;
+        }
+
+        [UnityTest]
+        public IEnumerator twoTypesAddedMethodTest() {
+            // TODO: this could be more robust by adding in x randomly named items
+            addNewItemToInventory(ITEM_ONE);
+            addNewItemToInventory(ITEM_TWO);
+
+            // make sure the total different types returned is correct
+            Assert.AreEqual(2, inventory.GetUniqueItemCount(),
+                "Adding 2 different types of items is not accurately reported by the inventory.");
+            yield return null;
+        }
+
+        [UnityTest]
+        public IEnumerator itemOrderTest() {
+            Item itemOne = addNewItemToInventory(ITEM_ONE);
+            Item itemTwo = addNewItemToInventory(ITEM_TWO);
+
+            // this checks the order at which items are added, is the order that they appear in the inventory
+            Assert.AreEqual(itemOne, inventory.GetItemAt(0),
+                "Item that was added first does not show up first in the inventory.");
+            Assert.AreEqual(itemTwo, inventory.GetItemAt(1),
+                "Item that was added second does not show up as second in the inventory.");
+            yield return null;
+        }
+    }
+}

--- a/Assets/Tests/Inventory/Inventory_AddingTests.cs.meta
+++ b/Assets/Tests/Inventory/Inventory_AddingTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9051161ebef97854c888ee654777aec8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Inventory/Inventory_ListenerTests.cs
+++ b/Assets/Tests/Inventory/Inventory_ListenerTests.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Tests {
+    public class Inventory_ListenerTests : InventoryBasetest {
+
+        private int someValueToIncrement = 0;
+
+        [UnityTest]
+        public IEnumerator methodToBeCalledOnInventoryUpdateTest() {
+            // add a very simple method to this, to listen for inventory updates
+            inventory.OnInventoryChange += simpleMethod;
+
+            // modify the inventory to force an expected listener call!
+            addNewItemToInventory(ITEM_ONE);
+
+            // simulates 1 Update frame to be called, thus, the added method should be called
+            yield return null;
+
+            Assert.AreEqual(1, someValueToIncrement, "Listener methods are not called when the inventory is updated.");
+        }
+
+        private void simpleMethod() {
+            someValueToIncrement = someValueToIncrement + 1;
+        }
+    }
+}

--- a/Assets/Tests/Inventory/Inventory_ListenerTests.cs.meta
+++ b/Assets/Tests/Inventory/Inventory_ListenerTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2fac95eb0376e66429e015ab28dbfc03
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Inventory/Inventory_RemovingTests.cs
+++ b/Assets/Tests/Inventory/Inventory_RemovingTests.cs
@@ -1,0 +1,77 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using com.runtime.GameJamBois.BGJ20201.Items;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Tests {
+    public class Inventory_RemovingTests : InventoryBasetest {
+
+        private Item addAndRemoveItem(string itemName) {
+            Item item = addNewItemToInventory(itemName);
+            inventory.Remove(item);
+            return item;
+        }
+
+        [UnityTest]
+        public IEnumerator removeAllItemsDictionaryTest() {
+            addAndRemoveItem(ITEM_ONE);
+
+            var dict = inventory.GetItemCountStorage();
+
+            Assert.IsFalse(dict.ContainsKey(ITEM_ONE),
+                "Key in the dictionary within the inventory is not wiped when all of that item are removed.");
+            yield return null;
+        }
+
+        [UnityTest]
+        public IEnumerator removeAllItemsOrderedArrayTest() {
+            Item item = addAndRemoveItem(ITEM_ONE);
+
+            ArrayList array = inventory.GetOrderedStorage();
+
+            Assert.IsFalse(array.Contains(item),
+                "Entry in the ordered array within the inventory is not removed when all of that item are removed.");
+            yield return null;
+        }
+
+        [UnityTest]
+        public IEnumerator simpleRemoveDecrementTest() {
+            Item item = getNewItem(ITEM_ONE);
+            int count = 10;
+            inventory.Add(item, count);
+
+            inventory.Remove(item);
+
+            Assert.AreEqual(count - 1, inventory.GetItemCount(item),
+                "Item is not decremented from the inventory when removing it.");
+            yield return null;
+        }
+
+        [UnityTest]
+        public IEnumerator removeXTest() {
+            Item item = getNewItem(ITEM_ONE);
+            int count = 10, remove = 5;
+            inventory.Add(item, count);
+
+            inventory.Remove(item, remove);
+
+            Assert.AreEqual(count - remove, inventory.GetItemCount(item),
+                "When removing a variable amount of items, they are not actually removed from the inventory.");
+            yield return null;
+        }
+
+        [UnityTest]
+        public IEnumerator tryToRemoveAnItemYouDontHaveTest() {
+            throwNotReadyYet();
+            yield return null;
+        }
+
+        [UnityTest]
+        public IEnumerator removeXWhenYouHaveLessThanXTest() {
+            throwNotReadyYet();
+            yield return null;
+        }
+    }
+}

--- a/Assets/Tests/Inventory/Inventory_RemovingTests.cs.meta
+++ b/Assets/Tests/Inventory/Inventory_RemovingTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9a566d21fe2c25748a1249a74ce52fcb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Inventory/Inventory_UtilitiesTest.cs
+++ b/Assets/Tests/Inventory/Inventory_UtilitiesTest.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using com.runtime.GameJamBois.BGJ20201.Items;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Tests {
+    public class Inventory_UtilitiesTests : InventoryBasetest {
+
+        [UnityTest]
+        public IEnumerator itemsToStartWithTest() {
+            ArrayList items = new ArrayList();
+
+            Item itemOne = getNewItem(ITEM_ONE);
+            Item itemTwo = getNewItem(ITEM_TWO);
+
+            items.Add(itemOne);
+            items.Add(itemTwo);
+
+            inventory.SetArrayForItemsToStartWith((Item[])items.ToArray(typeof(Item)));
+
+            // this simulates the 'Start' call
+            inventory.ProcessStartingItems();
+
+            Assert.IsTrue(inventory.DoesItemExist(itemOne) && inventory.DoesItemExist(itemTwo),
+                "Items added to the 'Items to Start With' array are not added to the inventory at the start.");
+
+            yield return null;
+        }
+
+        [UnityTest]
+        public IEnumerator noItemsToStartWithTest() {
+            // this simulates the 'Start' call
+            inventory.ProcessStartingItems();
+
+            // NOTE: when we have saving of inventories, this test may not pass.
+            Assert.IsTrue(inventory.GetUniqueItemCount() == 0,
+                "No items were provided to the 'Items to Start With' array, and yet there are items that started in the inventory.");
+
+            yield return null;
+        }
+    }
+}

--- a/Assets/Tests/Inventory/Inventory_UtilitiesTest.cs.meta
+++ b/Assets/Tests/Inventory/Inventory_UtilitiesTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 31090e175443dac45898dc4a067b20b6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Tests.asmdef
+++ b/Assets/Tests/Tests.asmdef
@@ -1,0 +1,21 @@
+{
+    "name": "Tests",
+    "references": [
+        "UnityEngine.TestRunner",
+        "UnityEditor.TestRunner",
+        "BGJ-2020-Assembly"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "nunit.framework.dll"
+    ],
+    "autoReferenced": false,
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Assets/Tests/Tests.asmdef.meta
+++ b/Assets/Tests/Tests.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: d3fdbdf89e37495439c8d51dc978911a
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/UnityPlayBaseTest.cs
+++ b/Assets/Tests/UnityPlayBaseTest.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using com.runtime.GameJamBois.BGJ20201.Items;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Tests{
+    public abstract class UnityPlayBaseTest {
+
+        protected const string ITEM_ONE = "TestItemOne";
+        protected const string ITEM_TWO = "TestItemTwo";
+
+        /// <summary>
+        /// Objects created by tests that you wish to remove!
+        /// </summary>
+        private ArrayList testGameObjectsToDestroy = new ArrayList();
+
+        /// <summary>
+        /// Creates a new GameObject,
+        /// and adds it to an internal list that tracks game objects to destroy.
+        /// </summary>
+        /// <returns></returns>
+        protected GameObject addGOAndStoreInDestroyList() {
+            GameObject newObj = new GameObject();
+            testGameObjectsToDestroy.Add(newObj);
+            return newObj;
+        }
+
+        /// <summary>
+        /// Same as above, but allows for one, or multiple, component types to be added.
+        /// </summary>
+        /// <returns></returns>
+        protected GameObject addGOAndStoreInDestroyList(params Type[] typesToAdd) {
+            GameObject obj = addGOAndStoreInDestroyList();
+            foreach (Type type in typesToAdd) {
+                obj.AddComponent(type);
+            }
+
+            return obj;
+        }
+
+        protected Item getNewItem(string name) {
+            GameObject go = addGOAndStoreInDestroyList(typeof(Item));
+            Item item = go.GetComponent<Item>();
+            item.construct(name);
+            return item;
+        }
+
+        protected void throwNotReadyYet() {
+            Assert.Inconclusive("Test not ready to be run yet!");
+        }
+
+        /// <summary>
+        /// Always will remove any GO's added to this list.
+        /// Useful for when you don't want any GO's to be leftover in a scene
+        /// after a test has run.
+        /// </summary>
+        [TearDown]
+        public void removeAllNewGameObjects() {
+            foreach (GameObject obj in testGameObjectsToDestroy) {
+                UnityEngine.Object.Destroy(obj);
+            }
+        }
+    }
+}

--- a/Assets/Tests/UnityPlayBaseTest.cs.meta
+++ b/Assets/Tests/UnityPlayBaseTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2213ce81132e62a448c8493952cd0b11
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
**Inventory/storage system:** 
- add, remove, and iterate over an inventory
- currently handles stacking without a limitation/stack limit
- includes an _event_ to subscribe to for when the inventory updates, making it super easy for UI scripts to get updated when the inventory does too
- pre-made unit tests brought over to hopefully make code changes quicker for the inventory
- ability to inject/initialize inventory in the inspector so you can test scenes with certain items

Had to pull out code that was super specific to my game. And after that, ran the tests I wrote and felt good when they all passed (nope didn't write these for this jam, I'm not crazy!)

Unit tests included; should we need special stacking later, should be easy to re-factor:
![inventory-tests](https://user-images.githubusercontent.com/8595173/74294559-e75b9180-4d03-11ea-9c41-24ce87b3a9d5.PNG)